### PR TITLE
fix: preserve markdown list formatting in changelog output

### DIFF
--- a/.changeset/fix-list-formatting.md
+++ b/.changeset/fix-list-formatting.md
@@ -1,0 +1,5 @@
+---
+"@stacc/changeset-formatter": patch
+---
+
+fix: preserve markdown list formatting in changelog output. Changeset descriptions using `- item` syntax no longer get double-nested as `- - item`.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -180,6 +180,61 @@ describe("Changeset formatter", () => {
     });
   });
 
+  describe("list formatting", () => {
+    it("should preserve markdown list items without double-nesting", async () => {
+      const result = await getReleaseLine(
+        ...getChangeset(
+          "",
+          data.commit,
+          true,
+          "- 🐛 **Bug** (credit-decision): Fix race condition\n- 🔌 **API** (party): Add error codes",
+        )
+      );
+      expect(result).toContain("- 🐛 **Bug** (credit-decision): Fix race condition");
+      expect(result).toContain("- 🔌 **API** (party): Add error codes");
+      expect(result).not.toContain("- - ");
+    });
+
+    it("should still add bullet for plain text summaries", async () => {
+      const result = await getReleaseLine(
+        ...getChangeset(
+          "",
+          data.commit,
+          true,
+          "Fix something important",
+        )
+      );
+      expect(result).toMatch(/^- Fix something important/);
+    });
+
+    it("should handle mixed list and non-list lines", async () => {
+      const result = await getReleaseLine(
+        ...getChangeset(
+          "",
+          data.commit,
+          true,
+          "- 🐛 **Bug**: Fix race condition\nSome additional context",
+        )
+      );
+      expect(result).toContain("- 🐛 **Bug**: Fix race condition");
+      expect(result).toContain("  Some additional context");
+    });
+
+    it("should append ticket refs to first list item", async () => {
+      const result = await getReleaseLine(
+        ...getChangeset(
+          "ticket: https://stacc-as.atlassian.net/browse/PRO-142",
+          data.commit,
+          true,
+          "- ✨ **Feature**: New thing\n- 🐛 **Bug**: Fix thing",
+        )
+      );
+      expect(result).toContain("- ✨ **Feature**: New thing (");
+      expect(result).toContain("[PRO-142]");
+      expect(result).toContain("- 🐛 **Bug**: Fix thing");
+    });
+  });
+
   describe.skip("multiple changes", () => {
     it("should only show credits after last change", async () => {
       // First change

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,8 @@ async function getReleaseLine(
       : undefined);
 
   // Build the release line in the requested format
-  let result = `- ${firstLine}`;
+  // If the body already uses markdown list syntax, preserve it instead of nesting
+  let result = firstLine.startsWith("- ") ? firstLine : `- ${firstLine}`;
 
   // Append reference links: PR and/or Jira
   const refs: string[] = [];
@@ -120,7 +121,11 @@ async function getReleaseLine(
   }
 
   if (futureLines.length > 0) {
-    result += "\n" + futureLines.map((line) => "  " + line).join("\n");
+    result +=
+      "\n" +
+      futureLines
+        .map((line) => (line.startsWith("- ") ? line : "  " + line))
+        .join("\n");
   }
 
   return result;


### PR DESCRIPTION
## Summary

When changeset descriptions use markdown list syntax (`- item`), the formatter wraps each entry in another `- ` prefix, creating nested lists (`- - item`) that render as double-indented bullets on GitHub.

**Before:**
```md
- - 🐛 **Bug** (credit-decision): Fix race condition
  - 🔌 **API** (party): Add error codes
```

**After:**
```md
- 🐛 **Bug** (credit-decision): Fix race condition
- 🔌 **API** (party): Add error codes
```

Two changes in `getReleaseLine`:
1. If `firstLine` already starts with `- `, don't prepend another `- `
2. If a continuation line starts with `- `, keep it as a top-level bullet instead of indenting with `  `

Plain text summaries (without `- ` prefix) continue to work as before.